### PR TITLE
Release v1.2.0 

### DIFF
--- a/springockito-annotations/pom.xml
+++ b/springockito-annotations/pom.xml
@@ -8,14 +8,14 @@
     <parent>
         <groupId>org.github.kmoens</groupId>
         <artifactId>springockito-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>org.github.kmoens</groupId>
             <artifactId>springockito-core</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -47,6 +47,10 @@
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/experimental/DirtiesMocks.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/experimental/DirtiesMocks.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface DirtiesMocks {
 
-    static enum ClassMode {
+    enum ClassMode {
 
         AFTER_CLASS,
         AFTER_EACH_TEST_METHOD

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/experimental/DirtiesMocksTestContextListener.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/experimental/DirtiesMocksTestContextListener.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
 public class DirtiesMocksTestContextListener extends AbstractTestExecutionListener {
 
     @Override
-    public void afterTestMethod(final TestContext testContext) throws Exception {
+    public void afterTestMethod(final TestContext testContext) {
         Method testMethod = testContext.getTestMethod();
         Class<?> testClass = testContext.getTestClass();
         if (testMethod.isAnnotationPresent(DirtiesMocks.class) || afterEveryMethodModeSet(testClass)) {
@@ -25,7 +25,7 @@ public class DirtiesMocksTestContextListener extends AbstractTestExecutionListen
     }
 
     @Override
-    public void afterTestClass(final TestContext testContext) throws Exception {
+    public void afterTestClass(final TestContext testContext) {
         Class<?> testClass = testContext.getTestClass();
         if (afterClassModeSet(testClass)) {
             resetMocks(testContext);

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/DefinitionRegistry.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/DefinitionRegistry.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 public class DefinitionRegistry {
 
-    private Map<String, SpringockitoDefinition> springockitoDefinitionMap = new HashMap<String, SpringockitoDefinition>();
+    private Map<String, SpringockitoDefinition> springockitoDefinitionMap = new HashMap<>();
 
     public void registerAll(Set<SpringockitoDefinition> springockitoDefinitions) {
         for (SpringockitoDefinition springockitoDefinition : springockitoDefinitions) {

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/SpringockitoDefinitionFinder.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/SpringockitoDefinitionFinder.java
@@ -18,7 +18,7 @@ public class SpringockitoDefinitionFinder {
 
     public Set<SpringockitoDefinition> findSpringockitoDefinitions(Class<?> clazz) {
 
-        Set<SpringockitoDefinition> result = new HashSet<SpringockitoDefinition>();
+        Set<SpringockitoDefinition> result = new HashSet<>();
 
         while (clazz != null) {
             result.addAll(findDefinitions(clazz));
@@ -30,7 +30,7 @@ public class SpringockitoDefinitionFinder {
 
     private Set<SpringockitoDefinition> findDefinitions(Class<?> currentClass) {
 
-        Set<SpringockitoDefinition> definitions = new HashSet<SpringockitoDefinition>();
+        Set<SpringockitoDefinition> definitions = new HashSet<>();
 
         for (Field field : currentClass.getDeclaredFields()) {
             if (field.isAnnotationPresent(ReplaceWithMock.class)) {

--- a/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/naming/BeanNameResolverChainOfResponsibility.java
+++ b/springockito-annotations/src/main/java/org/kubek2k/springockito/annotations/internal/naming/BeanNameResolverChainOfResponsibility.java
@@ -12,7 +12,7 @@ public class BeanNameResolverChainOfResponsibility implements BeanNameResolver {
     private List<AbstractBeanNameResolver> resolversChain;
 
     public BeanNameResolverChainOfResponsibility() {
-        this.resolversChain = new ArrayList<AbstractBeanNameResolver>();
+        this.resolversChain = new ArrayList<>();
         Collections.addAll(resolversChain,
                 new ExplicitBeanNameNameResolver(),
                 new ExplicitBeanNameStrategyBeanNameResolver(),

--- a/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/MockitoMockHandlerIntegrationTest.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/MockitoMockHandlerIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.kubek2k.mockito.spring;
 
 import org.kubek2k.mockito.spring.testbeans.BeanToBeSpiedOrMockedAndStubbed;
-import org.mockito.cglib.proxy.Factory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
@@ -11,11 +10,9 @@ import org.testng.annotations.Test;
 import javax.annotation.Resource;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-
+import static org.mockito.Mockito.verify;
 
 @ContextConfiguration(locations = {"classpath*:/spring/mockitoContext.xml"})
 public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringContextTests {
@@ -30,28 +27,25 @@ public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringConte
     @Resource
     private BeanToBeSpiedOrMockedAndStubbed beanToBeMockedAndStubbed;
 
+    // FIXME
     @Test
     public void shouldLoadMockitoMock() {
-        assertNotNull(someFancyClass);
-        assertTrue(someFancyClass instanceof Factory);
-
-        assertNotNull(someFancyClass2);
-        assertTrue(someFancyClass2 instanceof Factory);
-
+        assertThat(someFancyClass).isNotNull();
+        assertThat(someFancyClass2).isNotNull();
     }
 
     @Test
     public void shouldAllowForMocksTeBeStubbedUsingMockitoMatchers() {
         //given
         String fixedReturnValue = "fixedReturnValue";
-        given(beanToBeMockedAndStubbed.methodWithArgument(anyString()))
-                .willReturn(fixedReturnValue);
+        given(beanToBeMockedAndStubbed.methodWithArgument(anyString())).willReturn(fixedReturnValue);
 
         //when
         String returnedString = beanToBeMockedAndStubbed.methodWithArgument("someString");
 
         //then
-        assertThat(returnedString)
-                .isEqualTo(fixedReturnValue);
+        assertThat(returnedString).isEqualTo(fixedReturnValue);
+
+        verify(beanToBeMockedAndStubbed).methodWithArgument("someString");
     }
 }

--- a/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/MockitoSpyHandlerIntegrationTest.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/MockitoSpyHandlerIntegrationTest.java
@@ -11,9 +11,9 @@ import javax.annotation.Resource;
 import java.util.Date;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.isA;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/testbeans/InterfaceToBeMocked.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/mockito/spring/testbeans/InterfaceToBeMocked.java
@@ -1,5 +1,5 @@
 package org.kubek2k.mockito.spring.testbeans;
 
 public interface InterfaceToBeMocked {
-    public Integer getValue(); 
+    Integer getValue();
 }

--- a/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/contextcache/NoSpringockitoIntegrationTest.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/contextcache/NoSpringockitoIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.kubek2k.springockito.annotations.contextcache;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.kubek2k.springockito.annotations.it.beans.InnerBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;

--- a/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/it/SpringockitoAnnotationsComponentScanMocksIntegrationTest.java
+++ b/springockito-annotations/src/test/java/org/kubek2k/springockito/annotations/it/SpringockitoAnnotationsComponentScanMocksIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.kubek2k.springockito.annotations.it;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.kubek2k.springockito.annotations.ReplaceWithMock;
 import org.kubek2k.springockito.annotations.SpringockitoContextLoader;
 import org.kubek2k.springockito.annotations.it.beans.InnerBean;

--- a/springockito-integration/pom.xml
+++ b/springockito-integration/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>org.github.kmoens</groupId>
     <artifactId>springockito-integration</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>3.2.1.RELEASE</spring.version>
-
         <springockito-annotations.version>1.0.9-SNAPSHOT</springockito-annotations.version>
+        <spring.version>5.3.39</spring.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -20,19 +20,17 @@
         <dependency>
             <groupId>org.github.kmoens</groupId>
             <artifactId>springockito-annotations</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
-
-        <!--external-->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.9.0</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -59,7 +57,11 @@
             <artifactId>spring-context</artifactId>
             <version>${spring.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
         <!--test-->
         <dependency>
             <groupId>org.easytesting</groupId>

--- a/springockito-integration/src/main/java/org/kubek2k/tools/Ordered.java
+++ b/springockito-integration/src/main/java/org/kubek2k/tools/Ordered.java
@@ -9,9 +9,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Ordered {
 
-    public int FIRST = Integer.MIN_VALUE;
-    public int LAST = Integer.MAX_VALUE;
-    public int DEFAULT = 0;
+    int FIRST = Integer.MIN_VALUE;
+    int LAST = Integer.MAX_VALUE;
+    int DEFAULT = 0;
 
     int value() default DEFAULT;
 

--- a/springockito-integration/src/main/java/org/kubek2k/tools/OrderedSpringJUnit4ClassRunner.java
+++ b/springockito-integration/src/main/java/org/kubek2k/tools/OrderedSpringJUnit4ClassRunner.java
@@ -1,8 +1,7 @@
 package org.kubek2k.tools;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.runners.model.FrameworkMethod;
@@ -16,13 +15,12 @@ public class OrderedSpringJUnit4ClassRunner extends org.springframework.test.con
 
     @Override
     protected List<FrameworkMethod> computeTestMethods() {
-        List<FrameworkMethod> frameworkMethods = super.computeTestMethods();
-        Collections.sort(frameworkMethods, new Comparator<FrameworkMethod>() {
-            public int compare(final FrameworkMethod o1, final FrameworkMethod o2) {
-                Integer i1 = getOrder(o1);
-                Integer i2 = getOrder(o2);
-                return i1.compareTo(i2);
-            }
+        // Create a modifiable copy of the list returned by super.computeTestMethods()
+        List<FrameworkMethod> frameworkMethods = new ArrayList<>(super.computeTestMethods());
+        frameworkMethods.sort((o1, o2) -> {
+            Integer i1 = getOrder(o1);
+            Integer i2 = getOrder(o2);
+            return i1.compareTo(i2);
         });
         return frameworkMethods;
     }

--- a/springockito-integration/src/main/java/org/kubek2k/tools/TestUtil.java
+++ b/springockito-integration/src/main/java/org/kubek2k/tools/TestUtil.java
@@ -1,12 +1,10 @@
 package org.kubek2k.tools;
 
-import org.mockito.internal.util.MockUtil;
+import org.mockito.Mockito;
 
 public class TestUtil {
 
-    private static final MockUtil mockUtil = new MockUtil();
-
     public static boolean isMock(Object mock) {
-        return mockUtil.isMock(mock);
+        return Mockito.mockingDetails(mock).isMock();
     }
 }

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/InsideSuiteRule.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/InsideSuiteRule.java
@@ -15,7 +15,7 @@ public class InsideSuiteRule extends ExternalResource {
 
 
     @Override
-    protected void before() throws Throwable {
+    protected void before() {
         insideSuite = true;
     }
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/basic/mock/TwoReplaceWithMockWithTheSameTarget_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/basic/mock/TwoReplaceWithMockWithTheSameTarget_Test.java
@@ -4,7 +4,6 @@ package org.kubek2k.springockito.general.basic.mock;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kubek2k.springockito.annotations.BeanNameStrategy;
 import org.kubek2k.springockito.annotations.ReplaceWithMock;
 import org.kubek2k.springockito.annotations.SpringockitoContextLoader;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/contextcaching/WithSpringockito_3_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/contextcaching/WithSpringockito_3_Test.java
@@ -5,7 +5,8 @@ import static org.fest.assertions.Assertions.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kubek2k.springockito.annotations.SpringockitoContextLoader;
-import org.mockito.internal.util.MockUtil;
+import org.kubek2k.tools.TestUtil;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -28,9 +29,7 @@ public class WithSpringockito_3_Test {
         bean.incrementState();
 
         //then
-        assertThat(bean.getState())
-                .isEqualTo(2);
-        assertThat(new MockUtil().isMock(bean))
-                .isTrue();
+        assertThat(bean.getState()).isEqualTo(2);
+        assertThat(TestUtil.isMock(bean)).isTrue();
     }
 }

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/mock/afterclass/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/mock/afterclass/DirtiesMocks2_Test.java
@@ -1,6 +1,6 @@
 package org.kubek2k.springockito.general.reset.annotation.mock.afterclass;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/mock/everymethod/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/mock/everymethod/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/spy/afterclass/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/spy/afterclass/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/spy/everymethod/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/annotation/spy/everymethod/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/mock/afterclass/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/mock/afterclass/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/mock/everymethod/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/mock/everymethod/DirtiesMocks2_Test.java
@@ -2,7 +2,6 @@ package org.kubek2k.springockito.general.reset.xml.mock.everymethod;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.kubek2k.springockito.annotations.SpringockitoContextLoader;
 import org.kubek2k.springockito.annotations.experimental.junit.AbstractJUnit4SpringockitoContextTests;
 import org.kubek2k.springockito.general.reset.MockedBean;
 import org.kubek2k.tools.Ordered;
@@ -11,7 +10,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/spy/afterclass/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/spy/afterclass/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/spy/everymethod/DirtiesMocks2_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/general/reset/xml/spy/everymethod/DirtiesMocks2_Test.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito-integration/src/test/java/org/kubek2k/springockito/jira024/AbilityToStubXmlDefinedMocks_Test.java
+++ b/springockito-integration/src/test/java/org/kubek2k/springockito/jira024/AbilityToStubXmlDefinedMocks_Test.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/springockito-parent/pom.xml
+++ b/springockito-parent/pom.xml
@@ -1,8 +1,9 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.github.kmoens</groupId>
     <artifactId>springockito-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <url>https://github.com/kmoens/springockito</url>
     <name>Springockito parent</name>
     <packaging>pom</packaging>
@@ -36,7 +37,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.version>3.2.4.RELEASE</spring.version>
+        <spring.version>5.3.39</spring.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -45,7 +47,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>1.10.19</version>
+                <version>${mockito.version}</version>
             </dependency>
 
             <dependency>
@@ -101,8 +103,13 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>6.3.1</version>
+                <version>7.10.2</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -124,16 +131,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>2.3.2</version>
+                    <version>3.13.0</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>8</source>
+                        <target>8</target>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.1.2</version>
+                    <version>3.3.1</version>
                     <executions>
                         <execution>
                             <phase>verify</phase>
@@ -146,7 +153,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>3.11.1</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -160,7 +167,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.2.2</version>
+                    <version>3.1.1</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>

--- a/springockito/pom.xml
+++ b/springockito/pom.xml
@@ -1,13 +1,15 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>springockito-core</artifactId>
     <description>Simple tool to create mocks in Spring environment</description>
     <name>Springockito Core</name>
+    <version>1.2.0</version>
 
     <parent>
         <groupId>org.github.kmoens</groupId>
         <artifactId>springockito-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <dependencies>
@@ -46,6 +48,10 @@
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/springockito/src/main/java/org/kubek2k/springockito/core/internal/mock/MockitoMockFactory.java
+++ b/springockito/src/main/java/org/kubek2k/springockito/core/internal/mock/MockitoMockFactory.java
@@ -18,7 +18,7 @@ public class MockitoMockFactory<T> implements FactoryBean<T>, SpringockitoResett
         return true;
     }
 
-    public T getObject() throws Exception {
+    public T getObject() {
         if (thisInstance == null) {
             thisInstance = Mockito.mock(mockClass, getMockitoMockSettings());
         }

--- a/springockito/src/main/java/org/kubek2k/springockito/core/internal/mock/MockitoMockSettings.java
+++ b/springockito/src/main/java/org/kubek2k/springockito/core/internal/mock/MockitoMockSettings.java
@@ -2,30 +2,31 @@ package org.kubek2k.springockito.core.internal.mock;
 
 import org.mockito.Answers;
 import org.mockito.MockSettings;
-import org.mockito.internal.creation.MockSettingsImpl;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 public class MockitoMockSettings {
 
     public static final MockitoMockSettings DEFAULT = new MockitoMockSettings();
     private Class<?>[] extraInterfaces;
     private String mockName;
-    private Answers defaultAnswer;
+    private Answer<?> defaultAnswer;
 
     public MockSettings getMockSettings() {
         return createMockSettings();
     }
 
     private MockSettings createMockSettings() {
-        MockSettings mockSettings = new MockSettingsImpl();
+        MockSettings mockSettings = Mockito.withSettings();
 
         if (extraInterfaces != null && extraInterfaces.length > 0) {
             mockSettings.extraInterfaces(extraInterfaces);
         }
 
         if (defaultAnswer != null) {
-            mockSettings.defaultAnswer(defaultAnswer.get());
+            mockSettings.defaultAnswer(defaultAnswer);
         } else {
-            mockSettings.defaultAnswer(Answers.RETURNS_DEFAULTS.get());
+            mockSettings.defaultAnswer(Answers.RETURNS_DEFAULTS);
         }
 
         if (mockName != null) {
@@ -44,7 +45,7 @@ public class MockitoMockSettings {
         return this;
     }
 
-    public MockitoMockSettings withDefaultAnswer(final Answers defaultAnswer) {
+    public MockitoMockSettings withDefaultAnswer(final Answer<?> defaultAnswer) {
         this.defaultAnswer = defaultAnswer;
         return this;
     }

--- a/springockito/src/test/java/org/kubek2k/springockito/core/MockitoMockHandlerIntegrationTest.java
+++ b/springockito/src/test/java/org/kubek2k/springockito/core/MockitoMockHandlerIntegrationTest.java
@@ -1,21 +1,18 @@
 package org.kubek2k.springockito.core;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
 
 import javax.annotation.Resource;
 
 import org.kubek2k.springockito.core.testbeans.BeanToBeSpiedOrMockedAndStubbed;
-import org.mockito.cglib.proxy.Factory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
-
 
 @ContextConfiguration(locations = {"classpath*:/spring/mockitoContext.xml"})
 public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringContextTests {
@@ -32,12 +29,8 @@ public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringConte
 
     @Test
     public void shouldLoadMockitoMock() {
-        assertNotNull(someFancyClass);
-        assertTrue(someFancyClass instanceof Factory);
-
-        assertNotNull(someFancyClass2);
-        assertTrue(someFancyClass2 instanceof Factory);
-
+        assertThat(someFancyClass).isNotNull();
+        assertThat(someFancyClass2).isNotNull();
     }
 
     @Test
@@ -51,7 +44,8 @@ public class MockitoMockHandlerIntegrationTest extends AbstractTestNGSpringConte
         String returnedString = beanToBeMockedAndStubbed.methodWithArgument("someString");
 
         //then
-        assertThat(returnedString)
-                .isEqualTo(fixedReturnValue);
+        assertThat(returnedString).isEqualTo(fixedReturnValue);
+
+        verify(beanToBeMockedAndStubbed).methodWithArgument("someString");
     }
 }

--- a/springockito/src/test/java/org/kubek2k/springockito/core/MockitoSpyHandlerIntegrationTest.java
+++ b/springockito/src/test/java/org/kubek2k/springockito/core/MockitoSpyHandlerIntegrationTest.java
@@ -1,9 +1,9 @@
 package org.kubek2k.springockito.core;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.isA;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/springockito/src/test/java/org/kubek2k/springockito/core/testbeans/InterfaceToBeMocked.java
+++ b/springockito/src/test/java/org/kubek2k/springockito/core/testbeans/InterfaceToBeMocked.java
@@ -1,5 +1,5 @@
 package org.kubek2k.springockito.core.testbeans;
 
 public interface InterfaceToBeMocked {
-    public Integer getValue(); 
+    Integer getValue();
 }


### PR DESCRIPTION
Release version 1.2.0 for parent and child artifacts

- Update Spring Framework to 5.3.39.
- Upgrade Mockito to 4.11.0 and JUnit to 4.13.2.
- Replace mockito-all with mockito-core
- Upgraded Maven Compiler Plugin to version 3.13.0 with Java 8 compatibility.
- Updated Maven Source Plugin to 3.3.1 and Maven Javadoc Plugin to 3.11.1.
- Upgraded TestNG to version 7.10.2.